### PR TITLE
Fix Error that prevented parsing of PSOC Creator map files

### DIFF
--- a/MapParser/DwarfParser.cs
+++ b/MapParser/DwarfParser.cs
@@ -154,6 +154,10 @@ namespace MapViewer
             name = cu[COMPILATION_UNIT_NAME_INDEX];
             string[] ele = name.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
             string[] e2 = cu[9].Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+            if(ele.Contains("<") | ele.Contains(">") | ele.Contains(":") | ele.Contains(@"""") | ele.Contains("|") | ele.Contains("?") | ele.Contains("*") )
+            {
+                return String.Empty;
+            }
             if (!Path.IsPathRooted(ele[ele.Length - 1])) // Don't do anything if we already have the full path
                 name = Path.GetFullPath(e2[e2.Length - 1] + ele[ele.Length - 1]); // GetFullPath(baseDir, relativePath);
             else

--- a/MapParser/SymParser.cs
+++ b/MapParser/SymParser.cs
@@ -157,8 +157,10 @@ namespace MapViewer
                 {
                     Debug.WriteLineIf(DEBUG, "Unknown section");
                 }
-                Symbol sym = new Symbol(entries[3], path, Convert.ToUInt32(entries[0], 16), Convert.ToUInt32(entries[1], 16), secName); sym.GlobalScope = type;
-                Symbols.Add(sym);
+                if (path != String.Empty) {
+                    Symbol sym = new Symbol(entries[3], path, Convert.ToUInt32(entries[0], 16), Convert.ToUInt32(entries[1], 16), secName); sym.GlobalScope = type;
+                    Symbols.Add(sym);
+                }
             }
 
             prog_ind?.Invoke(true);


### PR DESCRIPTION
map viewer would try to parse "<artificial>" as a file path and would then through an exception never finishing the map file