### PR TITLE
Bugfix unknown symbols + added Tooltip

### DIFF
--- a/MapParser/frmMain.Designer.cs
+++ b/MapParser/frmMain.Designer.cs
@@ -389,6 +389,7 @@
             this.columnGlobal.AspectName = "GlobalScope";
             this.columnGlobal.HeaderFont = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Bold);
             this.columnGlobal.Text = "GLOBAL";
+            this.columnGlobal.ToolTipText = "G = Global\nS = Static\nH = Hidden";
             // 
             // symAddrColumn
             // 

--- a/MapParser/frmMain.cs
+++ b/MapParser/frmMain.cs
@@ -1,4 +1,4 @@
-﻿#define CREF
+#define CREF
 
 #region copyright
 /*
@@ -616,7 +616,14 @@ namespace MapViewer
 
             // Special aspect getter for address coz we want to see that in hex
             this.symAddrColumn.AspectGetter = (x) => { return ((Symbol)x).LoadAddress.ToString("X6"); };
-            colSection.AspectGetter = x => { return ((Symbol)x).SectionName[1].ToString().ToUpper(); };
+            colSection.AspectGetter = x => { 
+                // check what kind of section we have
+                if (((Symbol)x).SectionName.ToLower() == "unknown") {
+                    return "UNK";
+                }
+
+                return ((Symbol)x).SectionName[1].ToString().ToUpper();
+            };
             columnGlobal.AspectGetter = x =>
             {
                 int type = ((Symbol)x).GlobalScope;


### PR DESCRIPTION
When I first started using the tool the global column was not quite clear for me. After checking the code it made more sense. I added a tooltip for this:
![image](https://github.com/govind-mukundan/MapViewer/assets/9889898/2a879c3e-32b2-49a0-b12e-02b8279c254f)

Also fixed a bug where the Section column would show "N" as section for unknown sections. Now it shows "UNK"
![image](https://github.com/govind-mukundan/MapViewer/assets/9889898/c786ddbd-66a0-4ab0-a73f-7ccc7a062649)

Current master shows "N":
![image](https://github.com/govind-mukundan/MapViewer/assets/9889898/e78104fd-1d14-4fe2-84d3-f24e6c7c9a9f)


